### PR TITLE
Add lobby

### DIFF
--- a/frontend/src/components/WaitingModal.vue
+++ b/frontend/src/components/WaitingModal.vue
@@ -1,0 +1,16 @@
+<template>
+    <teleport to="body">
+        <div ref="modal-backdrop" class="fixed z-10 inset-0 overflow-y-auto bg-black bg-opacity-50">
+            <div class="flex items-start justify-center min-h-screen pt-24 text-center">
+                <div class="bg-white rounded-lg flex flex-col items-center space-y-6 overflow-hidden shadow-xl p-8 w-1/2" ref="modal">
+                    <h1 class="text-4xl font-semibold">Waiting for Opponent</h1>
+                    <p>
+                        Please ensure your opponent has a working link, copy the link from the address bar above
+                        for a fresh link.
+                    </p>
+                    <div style="border-top-color:transparent" class="w-16 h-16 border-4 border-blue-400 rounded-full animate-spin"></div>
+                </div>
+            </div>
+        </div>
+    </teleport>
+</template>

--- a/frontend/src/views/Game.vue
+++ b/frontend/src/views/Game.vue
@@ -1,8 +1,8 @@
 <template>
         <navbar />
+        <waiting-modal v-if="players.length < 2" />
 
         <main class="w-full flex flex-col min-h-screen h-screen p-6 space-y-4 bg-gray-100">
-            {{ storeData }}
             <scoreboard v-if="players.length === 2" :players="players" />
 
             <div class="w-full flex h-full space-x-4">
@@ -36,6 +36,7 @@ import Card from '@/components/Card.vue'
 import Navbar from '@/components/Navbar.vue'
 import Chatbox from '@/components/Chatbox.vue'
 import Scoreboard from '@/components/Scoreboard.vue'
+import WaitingModal from '@/components/WaitingModal.vue'
 
 export default{
     name: "Game",
@@ -56,6 +57,7 @@ export default{
         Navbar,
         Chatbox,
         Scoreboard,
+        WaitingModal,
     },
 
     methods: {


### PR DESCRIPTION
"Waiting for Lobby" modal will now appear in front of the Game board if less than 2 players have joined the lobby. This adds some more professionalism to the game rather than if the player simply loads into the lobby and has to wait for all of the assets to load in.

![image](https://user-images.githubusercontent.com/52263746/145735003-dbc46430-27d8-42da-92ea-13c474f62c4c.png)
